### PR TITLE
Reversed AR Default Timezone to UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ module RetsuQ
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_record.default_timezone = :utc
     config.time_zone = "Asia/Tokyo"
-    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
The following error was raised when accessing localhost/owner :

ActiveRecord::Base.default_timezone must be :utc to use Groupdate

I changed it back to utc and put the [ActiveRecord::Base.default_timezone] and [config.timezone] in reverse order.