### PR TITLE
Styled the UI on the queue management page

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,16 +1,16 @@
 .btn-action {
   background-color: #1EDD88;
-  padding: 3px 10px 5px 10px;
-  border-radius: 5px;
-  width: 120px;
-  height: 60px;
-  // border: 1px solid black;
+  padding: 8px 4px;
+  border-radius: 10px;
+  width: 112px;
   text-decoration: none;
   p {
-    margin-top: auto;
     color: $black;
     text-decoration: none;
     vertical-align: middle;
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 6px!important;
   }
 }
 
@@ -56,6 +56,7 @@ a.signup:hover {
 
 .no-btn-style {
   border: 0px solid transparent;
+  background: none;
 }
 .no-btn-style:hover {
 transform: scale(1.05);

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,24 +1,96 @@
 /* Restaurant cards (queuers) */
 
-.queuers-card {
-  display: flex;
-  width: 100%;
-  margin-bottom: 2em;
+.queuers-card-bg:hover {
+  background: $queuing!important;
+  transition: 0.05s ease-in-out;
 }
-.queuers-card-preview {
+
+.queuers-card-bg.dining:hover {
+  background: $dining!important;
+  transition: 0.05s ease-in-out;
+}
+
+.queuers-card-bg.completed:hover {
+  background: $completed!important;
+  transition: 0.05s ease-in-out;
+}
+
+.queuers-card {
+  display: grid;
+  font-size: 16px;
+  width: 100%;
+  grid-template-columns: 1fr 3fr 4fr 4fr;
+  padding: 1em;
+
+  p {
+    margin: 0;
+  }
+
+  svg {
+    height: 25px;
+    width: auto;
+  }
+
+  .reservation-name {
+    font-size: 22px;
+  }
+
+  .email {
+    font-size: 0.8em;
+  }
+}
+
+.queuer-index {
+  height: 30px;
+  width: 30px;
+  border-radius: 50%;
+  background: $queuing;
+  color: $black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  align-self: center;
+  padding: 1em;
+
+  &.dining {
+    background: $dining;
+  }
+
+  &.completed {
+    background: $completed;
+  }
+}
+
+.queuers-card-name, .queuers-card-size {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.queuers-card-size p {
+  font-size: 12px;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+}
+
+.queuers-card-size-number {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 2.5em;
+  margin-right: 8px;
+}
+
+.queuers-card-info {
   border: 1px solid transparent;
-  width: 200px;
   text-transform: uppercase;
   justify-content: center;
   flex-grow: 1;
-  background: #F0F0F0;
-
-
 }
 
 .queuers-card-status {
   width: 200px;
-  background: #D9D9D9;
   flex-grow: 1;
   text-align: center;
   vertical-align: middle;
@@ -30,8 +102,6 @@
 
 .queuers-card-action {
   display: flex;
-  width: 200px;
-  background: #F0F0F0;
   flex-grow: 2;
   text-align: center;
   justify-content: space-evenly;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -9,7 +9,12 @@ $light-gray: #F4F4F4;
 $white: #FFFFFF;
 $queuing: #FFD166;
 $completed: #118AB2;
-$dining: #06D6A0;
+// $dining: #06D6A0;
+
+$dining: #68B684;
+$remove: #c63f3d;
+$completed: #2E86AB;
+
 
 .queuers-card-status {
 
@@ -26,7 +31,7 @@ $dining: #06D6A0;
   }
 
   &.remove {
-    background-color: #EF476F;
+    background-color: $remove;
   }
 
 }
@@ -46,7 +51,7 @@ $dining: #06D6A0;
   }
 
   &.remove {
-    background-color: #EF476F;
+    background-color: $remove;
   }
 
 }

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,3 +1,4 @@
 // Import page-specific CSS files here.
 @import "home";
 @import "owner_dashboard";
+@import "owner_queue_management";

--- a/app/assets/stylesheets/pages/_owner_queue_management.scss
+++ b/app/assets/stylesheets/pages/_owner_queue_management.scss
@@ -1,0 +1,16 @@
+.queuers-tableheaders {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3em;
+  padding: 0 8px;
+
+  h2 {
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  svg {
+    width: 4em;
+    height: auto;
+  }
+}

--- a/app/controllers/queuers_controller.rb
+++ b/app/controllers/queuers_controller.rb
@@ -34,9 +34,13 @@ class QueuersController < ApplicationController
     @restaurant = Restaurant.where(user_id: current_user.id)
     # <!-- Active Queuers -->
     @queuers = Queuer.where(restaurant_id: @restaurant, status: "queuing")
+    @number_of_queuers = @queuers.size
+    # <!-- Active Diners -->
     @dining_queuers = Queuer.where(restaurant_id: @restaurant, status: "dining")
-    @queuers = @queuers += @dining_queuers
-    @queuers = @queuers.sort_by { |queue| queue.created_at }
+    @number_of_diners = @dining_queuers.size
+
+    @all_queuers = @queuers += @dining_queuers
+    @all_queuers = @queuers.sort_by { |queue| queue.created_at }
     # <!-- Total Queuers -->
     @total_queuers = Queuer.where(restaurant_id: @restaurant)
     @total_queuers = @total_queuers.sort_by { |queue| queue.created_at }

--- a/app/views/queuers/_active.html.erb
+++ b/app/views/queuers/_active.html.erb
@@ -1,61 +1,136 @@
-<div class=" d-flex align-items-center justify-content-between mb-3">
-  <div>
-    <h3 class="mt-5 mb-2">My Queue</h3>
-  </div>
-  <div>
-    <h3 class="mt-5 mb-2"><%= @queuers.size %> Active Queuers</h3>
-  </div>
-  <div>
-    <h3 class="mt-5 mb-2"><%= @number_of_people %> Active Customers</h3>
-  </div>
 </div>
 
-<div id="queuers">
-  <% @queuers.each_with_index do | queue, index | %>
-  <%= content_tag :div, id: dom_id(queue) do %>
-    <div class="queuers-card shadow">
-      <div class="queuers-card-preview">
-      <div class="d-flex justify-content-between">
-        <p><%= queue.reservation_name %></p>
-        <% if queue.size === 1 %>
-          <p class=" "><%= queue.size %> Guest</p>
-        <% else %>
-          <p class=" "><%= queue.size %> Guests</p>
-          <% end %>
-      </div>
-      <p class=" "><%= queue.user.email %></p>
+<div class="container p-2">
+    <!-- Active Queue -->
+    <div class="queuers-tableheaders">
+      <h2>Queue</h2>
+      <h3><%= @queuers.size %> groups waiting (<%= @number_of_people %> queuers)</h3>
+    </div>
+</div>
 
-      </div>
-        <div class="queuers-card-status status"><%= queue.status %></div>
+    <div id="queuers">
+      <% @queuers.each_with_index do | queue, index | %>
+      <% if queue.status == "queuing" %>
+        <%= content_tag :div, id: dom_id(queue) do %>
+          <div class="queuers-card-bg" <% if index.even? %>
+              style="background-color: #eeeeee;"
+              <% end %>>
+            <div class="queuers-card container">
+              <div class="queuer-index"><p><%= index + 1 %></p>
+              </div>
+              <div class="queuers-card-name">
+                <p class="email"><%= queue.user.email %></p>
+                <p class="reservation-name"><%= queue.reservation_name %></p>
+              </div>
+              <div class="queuers-card-size">
+                <% if queue.size === 1 %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span><span> Guest</p>
+                <% else %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span> Guests</p>
+                  <% end %>
+              </div>
 
-      <div class="queuers-card-action">
-        <% Queuer::STATUS.each do |status| %>
-          <%= button_to change_status_queuer_path(@queuers[index], status: status), method: :patch, class: "no-btn-style" do %>
-          <% if status === "dining" %>
-            <div class="btn-action shadow dining">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><title>romantic-restaurant</title><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="none" stroke="#212121"><line x1="8" y1="20" x2="24" y2="20"></line><line x1="16" y1="31" x2="16" y2="20"></line><line x1="31" y1="18" x2="31" y2="31"></line><polyline points="31 25 23 25 23 31"></polyline><line x1="1" y1="18" x2="1" y2="31"></line><polyline points="1 25 9 25 9 31"></polyline><path d="M21.881,2.157A3.74,3.74,0,0,0,16,2.768a3.741,3.741,0,0,0-5.882-.611,4.051,4.051,0,0,0,0,5.589L16,13.834l5.883-6.088A4.049,4.049,0,0,0,21.881,2.157Z" stroke="#212121"></path></g></svg>
-              <p>Dining</p>
+
+              <div class="queuers-card-action">
+                <% Queuer::STATUS.each do |status| %>
+                  <%= button_to change_status_queuer_path(@queuers[index], status: status), method: :patch, class: "no-btn-style" do %>
+                  <% if status === "dining" %>
+                    <div class="btn-action shadow dining">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>romantic-restaurant</title><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="none" stroke="#212121"><line x1="8" y1="20" x2="24" y2="20"></line><line x1="16" y1="31" x2="16" y2="20"></line><line x1="31" y1="18" x2="31" y2="31"></line><polyline points="31 25 23 25 23 31"></polyline><line x1="1" y1="18" x2="1" y2="31"></line><polyline points="1 25 9 25 9 31"></polyline><path d="M21.881,2.157A3.74,3.74,0,0,0,16,2.768a3.741,3.741,0,0,0-5.882-.611,4.051,4.051,0,0,0,0,5.589L16,13.834l5.883-6.088A4.049,4.049,0,0,0,21.881,2.157Z" stroke="#212121"></path></g></svg>
+                      <p>Dining</p>
+                    </div>
+                  <% elsif status === "completed" %>
+                    <div class="btn-action shadow completed">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>person_remove_alt_1</title><g fill="none"><path d="M14 8c0-2.21-1.79-4-4-4S6 5.79 6 8s1.79 4 4 4 4-1.79 4-4zm3 2v2h6v-2h-6zM2 18v2h16v-2c0-2.66-5.33-4-8-4s-8 1.34-8 4z" fill="#212121"></path></g></svg>
+                      <p>Finished</p>
+                    </div>
+                  <% else %>
+                    <div class="btn-action shadow queuing">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>time-machine</title><g fill="#212121"><path d="M12,0A12.013,12.013,0,0,0,0,12a1,1,0,0,0,2,0,10.023,10.023,0,1,1,4.379,8.26L8.184,18a.5.5,0,0,0-.349-.809l-6.672-.568a.5.5,0,0,0-.519.65l2.042,6.377a.5.5,0,0,0,.385.339.476.476,0,0,0,.091.009.5.5,0,0,0,.391-.189l1.578-1.98A12,12,0,1,0,12,0Z" fill="#212121"></path><path d="M12,4a1,1,0,0,0-1,1v7a1,1,0,0,0,1,1h7a1,1,0,0,0,0-2H13V5A1,1,0,0,0,12,4Z"></path></g></svg>
+                      <p>Queuing</p>
+                    </div>
+                  <% end %>
+                  <% end %>
+                <% end %>
+                  <%= button_to remove_queuer_queuer_path(@queuers[index]),method: :delete, class: "no-btn-style" do %>
+                  <div class="btn-action shadow remove">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>exit_to_app</title><g fill="none"><path d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5a2 2 0 0 0-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="#212121"></path></g></svg>
+                  <p>Remove</p></div>
+                  <% end %>
+              </div>
             </div>
-          <% elsif status === "completed" %>
-            <div class="btn-action shadow completed">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>person_remove_alt_1</title><g fill="none"><path d="M14 8c0-2.21-1.79-4-4-4S6 5.79 6 8s1.79 4 4 4 4-1.79 4-4zm3 2v2h6v-2h-6zM2 18v2h16v-2c0-2.66-5.33-4-8-4s-8 1.34-8 4z" fill="#212121"></path></g></svg>
-              <p>Finished</p>
-            </div>
-          <% else %>
-            <div class="btn-action shadow queuing">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>time-machine</title><g fill="#212121"><path d="M12,0A12.013,12.013,0,0,0,0,12a1,1,0,0,0,2,0,10.023,10.023,0,1,1,4.379,8.26L8.184,18a.5.5,0,0,0-.349-.809l-6.672-.568a.5.5,0,0,0-.519.65l2.042,6.377a.5.5,0,0,0,.385.339.476.476,0,0,0,.091.009.5.5,0,0,0,.391-.189l1.578-1.98A12,12,0,1,0,12,0Z" fill="#212121"></path><path d="M12,4a1,1,0,0,0-1,1v7a1,1,0,0,0,1,1h7a1,1,0,0,0,0-2H13V5A1,1,0,0,0,12,4Z"></path></g></svg>
-              <p>Queuing</p>
-            </div>
-          <% end %>
-          <% end %>
+          </div>
+
         <% end %>
-          <%= button_to remove_queuer_queuer_path(@queuers[index]),method: :delete, class: "no-btn-style" do %>
-          <div class="btn-action shadow remove">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>exit_to_app</title><g fill="none"><path d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5a2 2 0 0 0-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="#212121"></path></g></svg>
-          <p>Remove</p></div>
-          <% end %>
+      <% end %>
+      <% end %>
       </div>
     </div>
-    <% end %>
-  <% end %>
+    </div>
+
+    <!-- Active Diners -->
+    <div class="container p-2">
+        <!-- Active Queue -->
+        <div class="queuers-tableheaders">
+          <h2>Dining</h2>
+          <h3><%= @number_of_diners %> tables (<%= @number_of_people %> guests)</h3>
+        </div>
+    </div>
+
+    <div>
+      <% @dining_queuers.each_with_index do | queue, index | %>
+      <% if queue.status == "dining" %>
+        <%= content_tag :div, id: dom_id(queue) do %>
+          <div class="queuers-card-bg dining" <% if index.even? %>
+              style="background-color: #eeeeee;"
+              <% end %>>
+            <div class="queuers-card container">
+              <div class="queuer-index dining"><p><%= index + 1 %></p>
+              </div>
+              <div class="queuers-card-name">
+                <p class="email"><%= queue.user.email %></p>
+                <p class="reservation-name"><%= queue.reservation_name %></p>
+              </div>
+              <div class="queuers-card-size">
+                <% if queue.size === 1 %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span><span> Guest</p>
+                <% else %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span> Guests</p>
+                  <% end %>
+              </div>
+
+              <div class="queuers-card-action">
+                <% Queuer::STATUS.each do |status| %>
+                  <%= button_to change_status_queuer_path(@queuers[index], status: status), method: :patch, class: "no-btn-style" do %>
+                  <% if status === "dining" %>
+                    <div class="btn-action shadow dining">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><title>romantic-restaurant</title><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="none" stroke="#212121"><line x1="8" y1="20" x2="24" y2="20"></line><line x1="16" y1="31" x2="16" y2="20"></line><line x1="31" y1="18" x2="31" y2="31"></line><polyline points="31 25 23 25 23 31"></polyline><line x1="1" y1="18" x2="1" y2="31"></line><polyline points="1 25 9 25 9 31"></polyline><path d="M21.881,2.157A3.74,3.74,0,0,0,16,2.768a3.741,3.741,0,0,0-5.882-.611,4.051,4.051,0,0,0,0,5.589L16,13.834l5.883-6.088A4.049,4.049,0,0,0,21.881,2.157Z" stroke="#212121"></path></g></svg>
+                      <p>Dining</p>
+                    </div>
+                  <% elsif status === "completed" %>
+                    <div class="btn-action shadow completed">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>person_remove_alt_1</title><g fill="none"><path d="M14 8c0-2.21-1.79-4-4-4S6 5.79 6 8s1.79 4 4 4 4-1.79 4-4zm3 2v2h6v-2h-6zM2 18v2h16v-2c0-2.66-5.33-4-8-4s-8 1.34-8 4z" fill="#212121"></path></g></svg>
+                      <p>Finished</p>
+                    </div>
+                  <% else %>
+                    <div class="btn-action shadow queuing">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>time-machine</title><g fill="#212121"><path d="M12,0A12.013,12.013,0,0,0,0,12a1,1,0,0,0,2,0,10.023,10.023,0,1,1,4.379,8.26L8.184,18a.5.5,0,0,0-.349-.809l-6.672-.568a.5.5,0,0,0-.519.65l2.042,6.377a.5.5,0,0,0,.385.339.476.476,0,0,0,.091.009.5.5,0,0,0,.391-.189l1.578-1.98A12,12,0,1,0,12,0Z" fill="#212121"></path><path d="M12,4a1,1,0,0,0-1,1v7a1,1,0,0,0,1,1h7a1,1,0,0,0,0-2H13V5A1,1,0,0,0,12,4Z"></path></g></svg>
+                      <p>Queuing</p>
+                    </div>
+                  <% end %>
+                  <% end %>
+                <% end %>
+                  <%= button_to remove_queuer_queuer_path(@queuers[index]),method: :delete, class: "no-btn-style" do %>
+                  <div class="btn-action shadow remove">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>exit_to_app</title><g fill="none"><path d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5a2 2 0 0 0-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="#212121"></path></g></svg>
+                  <p>Remove</p></div>
+                  <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+      <% end %>
+      </div>
+    </div>
   </div>

--- a/app/views/queuers/_history.html.erb
+++ b/app/views/queuers/_history.html.erb
@@ -1,58 +1,66 @@
-<div class=" d-flex align-items-center justify-content-between mb-3">
-  <div>
-    <h3 class="mt-5 mb-2">Queue Hirtory</h3>
-  </div>
-  <div>
-    <h3 class="mt-5 mb-2"><%= @total_queuers.size %> Total Queuers</h3>
-  </div>
-</div>
-
-<div id="queuers">
-  <% @total_queuers.each_with_index do | queue, index | %>
-  <%= content_tag :div, id: dom_id(queue) do %>
-    <div class="queuers-card shadow">
-      <div class="queuers-card-preview">
-      <div class="d-flex justify-content-between">
-        <p><%= queue.reservation_name %></p>
-        <% if queue.size === 1 %>
-          <p class=" "><%= queue.size %> Guest</p>
-        <% else %>
-          <p class=" "><%= queue.size %> Guests</p>
-          <% end %>
-      </div>
-      <p class=" "><%= queue.user.email %></p>
-
-      </div>
-        <div class="queuers-card-status status"><%= queue.status %></div>
-
-      <div class="queuers-card-action">
-        <% Queuer::STATUS.each do |status| %>
-          <%= button_to change_status_queuer_path(@total_queuers[index], status: status), method: :patch, class: "no-btn-style" do %>
-          <% if status === "dining" %>
-            <div class="btn-action shadow dining">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><title>romantic-restaurant</title><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="none" stroke="#212121"><line x1="8" y1="20" x2="24" y2="20"></line><line x1="16" y1="31" x2="16" y2="20"></line><line x1="31" y1="18" x2="31" y2="31"></line><polyline points="31 25 23 25 23 31"></polyline><line x1="1" y1="18" x2="1" y2="31"></line><polyline points="1 25 9 25 9 31"></polyline><path d="M21.881,2.157A3.74,3.74,0,0,0,16,2.768a3.741,3.741,0,0,0-5.882-.611,4.051,4.051,0,0,0,0,5.589L16,13.834l5.883-6.088A4.049,4.049,0,0,0,21.881,2.157Z" stroke="#212121"></path></g></svg>
-              <p>Dining</p>
-            </div>
-          <% elsif status === "completed" %>
-            <div class="btn-action shadow completed">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>person_remove_alt_1</title><g fill="none"><path d="M14 8c0-2.21-1.79-4-4-4S6 5.79 6 8s1.79 4 4 4 4-1.79 4-4zm3 2v2h6v-2h-6zM2 18v2h16v-2c0-2.66-5.33-4-8-4s-8 1.34-8 4z" fill="#212121"></path></g></svg>
-              <p>Finished</p>
-            </div>
-          <% else %>
-            <div class="btn-action shadow queuing">
-              <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>time-machine</title><g fill="#212121"><path d="M12,0A12.013,12.013,0,0,0,0,12a1,1,0,0,0,2,0,10.023,10.023,0,1,1,4.379,8.26L8.184,18a.5.5,0,0,0-.349-.809l-6.672-.568a.5.5,0,0,0-.519.65l2.042,6.377a.5.5,0,0,0,.385.339.476.476,0,0,0,.091.009.5.5,0,0,0,.391-.189l1.578-1.98A12,12,0,1,0,12,0Z" fill="#212121"></path><path d="M12,4a1,1,0,0,0-1,1v7a1,1,0,0,0,1,1h7a1,1,0,0,0,0-2H13V5A1,1,0,0,0,12,4Z"></path></g></svg>
-              <p>Queuing</p>
-            </div>
-          <% end %>
-          <% end %>
-        <% end %>
-          <%= button_to remove_queuer_queuer_path(@total_queuers[index]),method: :delete, class: "no-btn-style" do %>
-          <div class="btn-action shadow remove">
-          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>exit_to_app</title><g fill="none"><path d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5a2 2 0 0 0-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="#212121"></path></g></svg>
-          <p>Remove</p></div>
-          <% end %>
-      </div>
+     <!-- Queue History -->
+    <div class="container p-2">
+        <!-- Active Queue -->
+        <div class="queuers-tableheaders">
+          <h2>History</h2>
+          <h3><%= @total_queuers.size %> guests</h3>
+        </div>
     </div>
-    <% end %>
-  <% end %>
-  </div>
+
+<div>
+      <% @total_queuers.each_with_index do | queue, index | %>
+      <% if queue.status == "completed" %>
+        <%= content_tag :div, id: dom_id(queue) do %>
+          <div class="queuers-card-bg completed" <% if index.even? %>
+              style="background-color: #eeeeee;"
+              <% end %>>
+            <div class="queuers-card container">
+              <div class="queuer-index completed"><p><%= index + 1 %></p>
+              </div>
+              <div class="queuers-card-name">
+                <p class="email"><%= queue.user.email %></p>
+                <p class="reservation-name"><%= queue.reservation_name %></p>
+              </div>
+              <div class="queuers-card-size">
+                <% if queue.size === 1 %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span><span> Guest</p>
+                <% else %>
+                  <p><span class="queuers-card-size-number"><%= queue.size %></span> Guests</p>
+                  <% end %>
+              </div>
+
+              <div class="queuers-card-action">
+                      <% Queuer::STATUS.each do |status| %>
+                        <%= button_to change_status_queuer_path(@total_queuers[index], status: status), method: :patch, class: "no-btn-style" do %>
+                        <% if status === "dining" %>
+                          <div class="btn-action shadow dining">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><title>romantic-restaurant</title><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="none" stroke="#212121"><line x1="8" y1="20" x2="24" y2="20"></line><line x1="16" y1="31" x2="16" y2="20"></line><line x1="31" y1="18" x2="31" y2="31"></line><polyline points="31 25 23 25 23 31"></polyline><line x1="1" y1="18" x2="1" y2="31"></line><polyline points="1 25 9 25 9 31"></polyline><path d="M21.881,2.157A3.74,3.74,0,0,0,16,2.768a3.741,3.741,0,0,0-5.882-.611,4.051,4.051,0,0,0,0,5.589L16,13.834l5.883-6.088A4.049,4.049,0,0,0,21.881,2.157Z" stroke="#212121"></path></g></svg>
+                            <p>Dining</p>
+                          </div>
+                        <% elsif status === "completed" %>
+                          <div class="btn-action shadow completed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>person_remove_alt_1</title><g fill="none"><path d="M14 8c0-2.21-1.79-4-4-4S6 5.79 6 8s1.79 4 4 4 4-1.79 4-4zm3 2v2h6v-2h-6zM2 18v2h16v-2c0-2.66-5.33-4-8-4s-8 1.34-8 4z" fill="#212121"></path></g></svg>
+                            <p>Finished</p>
+                          </div>
+                        <% else %>
+                          <div class="btn-action shadow queuing">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>time-machine</title><g fill="#212121"><path d="M12,0A12.013,12.013,0,0,0,0,12a1,1,0,0,0,2,0,10.023,10.023,0,1,1,4.379,8.26L8.184,18a.5.5,0,0,0-.349-.809l-6.672-.568a.5.5,0,0,0-.519.65l2.042,6.377a.5.5,0,0,0,.385.339.476.476,0,0,0,.091.009.5.5,0,0,0,.391-.189l1.578-1.98A12,12,0,1,0,12,0Z" fill="#212121"></path><path d="M12,4a1,1,0,0,0-1,1v7a1,1,0,0,0,1,1h7a1,1,0,0,0,0-2H13V5A1,1,0,0,0,12,4Z"></path></g></svg>
+                            <p>Queuing</p>
+                          </div>
+                        <% end %>
+                        <% end %>
+                      <% end %>
+                        <%= button_to remove_queuer_queuer_path(@total_queuers[index]),method: :delete, class: "no-btn-style" do %>
+                        <div class="btn-action shadow remove">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><title>exit_to_app</title><g fill="none"><path d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5a2 2 0 0 0-2 2v4h2V5h14v14H5v-4H3v4a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="#212121"></path></g></svg>
+                        <p>Remove</p></div>
+                        <% end %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+            <% end %>
+            </div>
+          </div>
+        </div>


### PR DESCRIPTION
Separated the dining and queuing lists, made the layout look closer to the original Figma.
Changed some of the colors in the variables.
Updated queuer#index to accomodate the page.
![image](https://user-images.githubusercontent.com/61854797/187817653-d26b43f7-b1d9-4bbc-bd19-0da9589b6fbe.png)
